### PR TITLE
@W-21355501: Pass slack webhook secret to release workflow

### DIFF
--- a/.github/workflows/create-github-release.yml
+++ b/.github/workflows/create-github-release.yml
@@ -18,6 +18,7 @@ jobs:
     uses: salesforcecli/github-workflows/.github/workflows/create-github-release.yml@main
     secrets:
       SVC_CLI_BOT_GITHUB_TOKEN: ${{ secrets.SVC_CLI_BOT_GITHUB_TOKEN }}
+      CLI_ALERTS_SLACK_WEBHOOK: ${{ secrets.CLI_ALERTS_SLACK_WEBHOOK }}
     with:
       prerelease: ${{ inputs.prerelease }}
       # If this is a push event, we want to skip the release if there are no semantic commits


### PR DESCRIPTION
Add `CLI_ALERTS_SLACK_WEBHOOK` secret to the `create-github-release` workflow so Slack notifications work when a release is skipped.

@W-21355501@