### PR TITLE
fix: resolving plugin collision (W-23473663)

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,20 @@ const {plugins: _, ...nodeRecommended} = nodePlugin.configs['flat/recommended']
 export default tseslint.config(
   eslint.configs.recommended,
   configs.recommended,
-  ...xo({space: true}).filter(c => ['xo/base', 'xo/ignores', 'xo/typescript'].includes(c.name)),
+  // Strip the '@typescript-eslint' and '@stylistic' plugins from xo's configs so they aren't
+  // registered twice. Both are direct dependencies here (via typescript-eslint and the '@stylistic'
+  // block below) and may resolve to a different version than the copies xo bundles; flat config
+  // throws "Cannot redefine plugin" when the same namespace is registered with two non-identical
+  // plugin objects. We register both namespaces ourselves, so xo can reference their rules without
+  // re-declaring the plugins.
+  ...xo({space: true})
+  .filter(c => ['xo/base', 'xo/ignores', 'xo/typescript'].includes(c.name))
+  .map(c => {
+    if (!c.plugins) return c
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    const {'@stylistic': _stylistic, '@typescript-eslint': _tsPlugin, ...plugins} = c.plugins
+    return {...c, plugins}
+  }),
   mocha.configs.recommended,
   nodeRecommended,
   perfectionist.configs['recommended-natural'],


### PR DESCRIPTION
Supplemental PR for @W-23473663@, resolving potential collisions between the versions of the plugins we require directly and those defined by eslint-config-xo.

The problem had led to a scenario where eslint-config-oclif@7.1.4 could not be used by child versions because of the possibility that `eslint-config-xo/typescript-eslint` and the top-level `typescript-eslint` would be different versions, which is disallowed in ESLint.